### PR TITLE
Added String for background Color when using Line Chart

### DIFF
--- a/components/chart.component.ts
+++ b/components/chart.component.ts
@@ -380,7 +380,7 @@ export namespace Chart {
     /**
      * The fill color under the line. See Colors
      */
-    backgroundColor?: string[];
+    backgroundColor?: string|string[];
     /**
      * The width of the line in pixels
      */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-chartjs2",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "description": "Chart.js 2.0 definitions for Angular 2",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Background Color shows default color when using Line Chart and passing array of Strings. It works fine when using a String